### PR TITLE
Ryan, Peyman, Abeve, Olivia, Erik -- 50/50 Points

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/contribution.md
+++ b/contribution.md
@@ -1,0 +1,20 @@
+# Team members
+Ryan Milvenan
+Erik Eakins
+Peyman Mortazavi
+Abeve Tayachow
+Olivia Abrant
+
+# Score
+50/50
+
+# Meeting Location
+CSEL
+
+# Meeting Time
+8:00 - 9:45
+
+# Bug
+When the iteration encounters the picture file and attempts to access its "filepath" property, the compiler warns that the filepath doesn't exist. How to fix?
+
+.DS_Store files are created by Mac OS for its indexing and storing information for each directory. When you browse your files in finder, .DS_Store files will be automatically created for every folder you browse. Now the problem here is that Wintersmith tries to read these files and since it doesn't have permission to do so, it'll say can't find the file path. How to fix this? tell Wintersmith to ignore .DS_Store files. How? modify config.json and add "ignoe": ["**/.DS_Store"] which means for all sub-directories, ignore .DS_Store files.

--- a/lib/a.js
+++ b/lib/a.js
@@ -1,5 +1,6 @@
 module.exports = function(lib, node){
-	var attributes = 'attributes-not-yet-implemented'
-	var contents = 'contents-not-yet-implemented'
-	return '<a ' + attributes + '>' + contents + '</a>'
+	var attributes = lib.parseAttributes(node);
+	var contents = lib.parseContent(node);
+	
+	return '<a' + attributes + '>' + contents + '</a>'
 }

--- a/lib/h1.js
+++ b/lib/h1.js
@@ -1,5 +1,19 @@
-module.exports = function(lib, node){
-	var attributes = 'attributes-not-yet-implemented'
+var util = require('util')
+module.exports = function(lib, node)
+{
 	var contents = node.text
+	var child = false
+	if (node.attrs) 
+	{
+		child = true
+		var attributes = node.attrs[0]
+		var name = attributes.name
+		var value = attributes.val
+		value = value.substring(1,(value.length)-1)
+	}
+	if (child == true)
+	{
+		return '<h1 '+name+'='+'"'+value+'"'+'>' + node.text + '</h1>'	
+	}
 	return '<h1>' + node.text + '</h1>'
 }

--- a/lib/h1.js
+++ b/lib/h1.js
@@ -1,5 +1,6 @@
 module.exports = function(lib, node){
-	var attributes = 'attributes-not-yet-implemented'
-	var contents = node.text
-	return '<h1>' + node.text + '</h1>'
+	var attributes = lib.parseAttributes(node);
+	var contents = lib.parseContent(node);
+
+	return '<h1' + attributes + '>' + contents + '</h1>';
 }

--- a/lib/h2.js
+++ b/lib/h2.js
@@ -1,5 +1,5 @@
 module.exports = function(lib, node){
 	var attributes = 'attributes-not-yet-implemented'
-	var contents = 'contents-not-yet-implemented'
+	var contents = node.text
 	return '<h2>' + contents + '</h2>'
 }

--- a/lib/h2.js
+++ b/lib/h2.js
@@ -1,5 +1,6 @@
 module.exports = function(lib, node){
-	var attributes = 'attributes-not-yet-implemented'
-	var contents = 'contents-not-yet-implemented'
-	return '<h2>' + contents + '</h2>'
+	var attributes = lib.parseAttributes(node);
+	var contents = lib.parseContent(node);
+
+	return '<h2' + attributes + '>' + contents + '</h2>';
 }

--- a/lib/jaded.js
+++ b/lib/jaded.js
@@ -12,6 +12,45 @@ var a = require('./a.js'),
 
 var lib = module.exports = {}
 
+lib.parseAttributes = function(node) {
+	
+	var attributes = "";
+
+    if(!node.attrs)
+        return "";
+
+    attributes += " ";
+
+	node.attrs.forEach( function (attribute) {
+		attributes += attribute.name + "=" + lib.validateStringValue( attribute.val );
+	});
+	
+	return attributes;
+
+}
+
+lib.validateStringValue = function(value) {
+	return String(value).replace(/'/g, "\"");
+}
+
+lib.parseContent = function(node) {
+	
+    if(node.children)
+    {
+        return lib.render(node);
+    }
+	else if(node.text) {
+		return node.text;
+	}
+	else if(node.contents) {
+		return node.contents.text;
+	}
+	else {
+		return "not supported, sorry.";
+	}
+
+}
+
 // main function to export
 lib.render = function(node) {
 


### PR DESCRIPTION
# Team members

Ryan Milvenan
Erik Eakins
Peyman Mortazavi
Abeve Tayachow
Olivia Abrant
# Score

50/50
# Meeting Location

CSEL
# Meeting Time

8:00 - 9:45
# Bug

When the iteration encounters the picture file and attempts to access its "filepath" property, the compiler warns that the filepath doesn't exist. How to fix?

.DS_Store files are created by Mac OS for its indexing and storing information for each directory. When you browse your files in finder, .DS_Store files will be automatically created for every folder you browse. Now the problem here is that Wintersmith tries to read these files and since it doesn't have permission to do so, it'll say can't find the file path. How to fix this? tell Wintersmith to ignore .DS_Store files. How? modify config.json and add "ignore": ["**/.DS_Store"] which means for all sub-directories, ignore .DS_Store files. This solution can be extended to picture file types as in the example.
