### PR TITLE
Brian, Chris, Jake, Hayden, Sam 50/50

### DIFF
--- a/lib/a.js
+++ b/lib/a.js
@@ -2,6 +2,7 @@ module.exports = function(lib, node){
 	var attributes = "";
 	var contents = "";
 	if (node.children) contents = lib.render(node);
+    else contents = node.text;
 	for (var j = 0; j < node.attrs.length; j++) {
 		attributes += node.attrs[j].name + "=" + node.attrs[j].val.replace(/'/g, '"');
 	}

--- a/lib/a.js
+++ b/lib/a.js
@@ -1,5 +1,9 @@
 module.exports = function(lib, node){
-	var attributes = 'attributes-not-yet-implemented'
-	var contents = 'contents-not-yet-implemented'
-	return '<a ' + attributes + '>' + contents + '</a>'
+	var attributes = "";
+	var contents = "";
+	if (node.children) contents = lib.render(node);
+	for (var j = 0; j < node.attrs.length; j++) {
+		attributes += node.attrs[j].name + "=" + node.attrs[j].val.replace(/'/g, '"');
+	}
+	return '<a ' + attributes + '>' + contents + '</a>';
 }

--- a/lib/h1.js
+++ b/lib/h1.js
@@ -1,5 +1,17 @@
 module.exports = function(lib, node){
-	var attributes = 'attributes-not-yet-implemented'
-	var contents = node.text
-	return '<h1>' + node.text + '</h1>'
+	var attributes = ''
+	if('attrs' in node){
+	  for (var i = 0; i < node.attrs.length; i++) {
+	    attributes = ' ' + node.attrs[i].name + '=' + node.attrs[i].val
+	    attributes = attributes.replace("\'", "\"")
+	    attributes = attributes.replace("\'", "\"")
+	  }
+	}
+	if (node.children){
+	  var contents = lib.render(node)
+	}
+	else{
+	  var contents = node.text
+	}
+	return '<h1' + attributes +'>' + contents + '</h1>'
 }

--- a/lib/h2.js
+++ b/lib/h2.js
@@ -1,5 +1,16 @@
 module.exports = function(lib, node){
-	var attributes = 'attributes-not-yet-implemented'
-	var contents = node.text;
-	return '<h2>' + contents + '</h2>'
+	var attributes = ''
+	if('attrs' in node){
+	  for (var i = 0; i < node.attrs.length; i++) {
+	    attributes += " "  + node.attrs[i].name + '=' + node.attrs[i].val
+	    
+	  }
+	}
+	if (node.children){
+	  var contents = lib.render(node)
+	}
+	else{
+	  var contents = node.text
+	}
+	return '<h2' + attributes +'>' + contents + '</h2>'
 }

--- a/lib/h2.js
+++ b/lib/h2.js
@@ -1,5 +1,5 @@
 module.exports = function(lib, node){
 	var attributes = 'attributes-not-yet-implemented'
-	var contents = 'contents-not-yet-implemented'
+	var contents = node.text;
 	return '<h2>' + contents + '</h2>'
 }

--- a/lib/logic/forin.js
+++ b/lib/logic/forin.js
@@ -1,3 +1,4 @@
+// Brian Newsom Test
 // render multiple times
 // for [val] in [obj]
 module.exports = function(node) {


### PR DESCRIPTION
# Team members

Brian Newsom
Hayden Berge
Jake Smith
Sam Tobey (Partner programmed didn't actually have a commit)
Chris Audette
# Score

50/50
# Meeting Location

Engineering lobby (homeland)
# Meeting Time

9PM Thursday - 10:37 PM
# Bug

The bug is caused because jade is referencing 'people' as a folder assuming it is such.  This is a faulty assumption as in the picture given a picture file exists rather than a folder.

Though there are multiple approaches, we fixed the issue by checking for the ability to index into people and the existence of an index.md file within that folder so that there must be a valid folder and files or else the person is completely ignored from the jade rendering and thus the view.  This code looks like

```
if person['index.md'] != undefined
```

before rendering any html for each person in the loop.  This now skips over the image completely and correctly renders the page.
